### PR TITLE
Add opensource section with a few examples, and goldsky mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,13 @@
 
 Awesome ETL tools for blockchain data
 
+## Open source
+- [ethereum-etl](https://github.com/blockchain-etl/ethereum-etl) - Python scripts for ETL. Powers the Google Bigquery Datasets.
+- [graph-node](https://github.com/graphprotocol/graph-node) - Index data from blockchains and access via GraphQL
+- [reth-indexer](https://github.com/joshstevens19/reth-indexer) - Index data directly from a local Reth node with fast performance.
+
+
+## Cloud Services
+- [Goldsky Mirror](https://goldsky.com/products/mirror) - Real-time data pipelines for blockchain and subgraph data with SQL transforms and on-the-fly decoding. 
 - [QuickNode Streams](https://www.quicknode.com/streams) - Optimized streaming,
 with guaranteed delivery


### PR DESCRIPTION
* Add opensource section which rightfully should be on top. Of course had to add the ethereum-etl project as well. 
* Ordering by project age (perhaps we should make explicit?). It also happens to be alphabetical if that's more fair. 

Note on conflict: I work for goldsky